### PR TITLE
Make keyUsage compatible with OTPs wonky filtering

### DIFF
--- a/basic/openssl.cnf
+++ b/basic/openssl.cnf
@@ -45,10 +45,10 @@ keyUsage         = keyCertSign, cRLSign
 
 [ client_extensions ]
 basicConstraints = CA:false
-keyUsage         = digitalSignature
+keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.2
 
 [ server_extensions ]
 basicConstraints = CA:false
-keyUsage         = keyEncipherment
+keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1


### PR DESCRIPTION
If the `keyUsage` extension is specified, [this code](https://github.com/erlang/otp/blob/master/lib/ssl/src/ssl_cipher.erl#L2026-L2029) unhelpfully filters out cipher suites unless both `keyEncipherment` and `digitalSignature` are present. This might be a bug in OTP, but ensuring both values are present in `keyUsage` will prevent this issue from happening in an Erlang SSL/TLS environment