### PR TITLE
Support subjectAltName (SAN) for leaf certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ ifndef CN
 CN := $(shell hostname)
 endif
 
+ifndef CLIENT_ALT_NAME
+CLIENT_ALT_NAME := $(shell hostname)
+endif
+
+ifndef SERVER_ALT_NAME
+SERVER_ALT_NAME := $(shell hostname)
+endif
+
 ifndef NUMBER_OF_PRIVATE_KEY_BITS
 NUMBER_OF_PRIVATE_KEY_BITS := 2048
 endif
@@ -41,10 +49,20 @@ clean:
 	$(PYTHON) profile.py clean
 
 gen:
-	$(PYTHON) profile.py generate --password $(PASS) --common-name $(CN) --days-of-validity $(DAYS_OF_VALIDITY) --key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
+	$(PYTHON) profile.py generate --password $(PASS) \
+	--common-name $(CN) \
+	--client-alt-name $(CLIENT_ALT_NAME) \
+	--server-alt-name $(SERVER_ALT_NAME) \
+	--days-of-validity $(DAYS_OF_VALIDITY) \
+	--key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
 
 regen:
-	$(PYTHON) profile.py regenerate --password $(PASS) --common-name $(CN) --days-of-validity $(DAYS_OF_VALIDITY) --key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
+	$(PYTHON) profile.py regenerate --password $(PASS) \
+	--common-name $(CN) \
+	--client-alt-name $(CLIENT_ALT_NAME) \
+	--server-alt-name $(SERVER_ALT_NAME) \
+	--days-of-validity $(DAYS_OF_VALIDITY) \
+	--key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
 
 info:
 	$(PYTHON) profile.py info

--- a/basic/openssl.cnf
+++ b/basic/openssl.cnf
@@ -1,3 +1,10 @@
+# fallback values, as recommended in config(5)
+CLIENT_ALT_NAME="client.local"
+SERVER_ALT_NAME="server.local"
+
+CAN = $ENV::CLIENT_ALT_NAME
+SAN = $ENV::SERVER_ALT_NAME
+
 [ ca ]
 default_ca = test_root_ca
 
@@ -47,8 +54,20 @@ keyUsage         = keyCertSign, cRLSign
 basicConstraints = CA:false
 keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.2
+subjectAltName   = @client_alt_names
 
 [ server_extensions ]
 basicConstraints = CA:false
 keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
+subjectAltName   = @server_alt_names
+
+[ client_alt_names ]
+DNS.1 = $CAN
+# tls-gen is only meant to be used in development environments
+DNS.2 = localhost
+
+[ server_alt_names ]
+DNS.1 = $SAN
+# tls-gen is only meant to be used in development environments
+DNS.2 = localhost

--- a/tls_gen/cli.py
+++ b/tls_gen/cli.py
@@ -11,6 +11,10 @@ def build_parser():
                  help = "Private key password")
     p.add_option("-n", "--common-name", dest = "common_name", action = "store",
                  help = "Certificate CN (Common Name)", default = socket.gethostname())
+    p.add_option("--client-alt-name", dest = "client_alt_name", action = "store",
+                 help = "SAN (subject Alternative Name) for the client", default = socket.gethostname())
+    p.add_option("--server-alt-name", dest = "server_alt_name", action = "store",
+                 help = "SAN (subject Alternative Name) for the server", default = socket.gethostname())
     p.add_option("-b", "--key-bits", dest = "key_bits", action = "store",
                  help = "Number of private key bits",
                  type = "int", default = 4096)


### PR DESCRIPTION
Both client and server. Values default to the same value as CN.
"localhost" is one of the hardcoded names since tls-gen is meant to be
used in development and QA environments.

When extended to all profiles, it will address #9.