### PR TITLE
Always set up env for subjectAltName

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # -*- mode: BSDmakefile; tab-width: 8; indent-tabs-mode: nil -*-
 
-OPENSSL=openssl
+OPENSSL = openssl
 
 ifndef PYTHON
 PYTHON := python3

--- a/basic/openssl.cnf
+++ b/basic/openssl.cnf
@@ -1,9 +1,10 @@
-# fallback values, as recommended in config(5)
-CLIENT_ALT_NAME="client.local"
-SERVER_ALT_NAME="server.local"
+# Note: LibreSSL 2.2.7 does not correctly support environment variables
+# here and that is the version that ships with OS X High Sierra. So, we
+# replace text using Python and generate a temporary cnf file
 
-CAN = $ENV::CLIENT_ALT_NAME
-SAN = $ENV::SERVER_ALT_NAME
+common_name = @COMMON_NAME@
+client_alt_name = @CLIENT_ALT_NAME@
+server_alt_name = @SERVER_ALT_NAME@
 
 [ ca ]
 default_ca = test_root_ca
@@ -63,11 +64,11 @@ extendedKeyUsage = 1.3.6.1.5.5.7.3.1
 subjectAltName   = @server_alt_names
 
 [ client_alt_names ]
-DNS.1 = $CAN
-# tls-gen is only meant to be used in development environments
-DNS.2 = localhost
+DNS.1 = $common_name
+DNS.2 = $client_alt_name
+DNS.3 = localhost
 
 [ server_alt_names ]
-DNS.1 = $SAN
-# tls-gen is only meant to be used in development environments
-DNS.2 = localhost
+DNS.1 = $common_name
+DNS.2 = $server_alt_name
+DNS.3 = localhost


### PR DESCRIPTION
Also adds a warning about LibreSSL as that library does not substitute env variables the same way OpenSSL does, and the subjectAltName value in a generated cert will always be the fallback values