### PR TITLE
Add support for CRL in certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ ifndef CN
 CN := $(shell hostname)
 endif
 
+ifndef CRL
+CRL := "http://example.com/fake.crl.pem"
+endif
+
 ifndef CLIENT_ALT_NAME
 CLIENT_ALT_NAME := $(shell hostname)
 endif
@@ -53,6 +57,7 @@ gen:
 	--common-name $(CN) \
 	--client-alt-name $(CLIENT_ALT_NAME) \
 	--server-alt-name $(SERVER_ALT_NAME) \
+	--crl $(CRL) \
 	--days-of-validity $(DAYS_OF_VALIDITY) \
 	--key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
 
@@ -61,6 +66,7 @@ regen:
 	--common-name $(CN) \
 	--client-alt-name $(CLIENT_ALT_NAME) \
 	--server-alt-name $(SERVER_ALT_NAME) \
+	--crl $(CRL) \
 	--days-of-validity $(DAYS_OF_VALIDITY) \
 	--key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,6 @@ ifndef CN
 CN := $(shell hostname)
 endif
 
-ifndef CRL
-CRL := "http://example.com/fake.crl.pem"
-endif
-
 ifndef CLIENT_ALT_NAME
 CLIENT_ALT_NAME := $(shell hostname)
 endif
@@ -47,6 +43,10 @@ ifdef PASSWORD
 PASS = "$(PASSWORD)"
 endif
 
+ifdef CRL
+CRL := "--crl $(CRL)"
+endif
+
 all: regen verify
 
 clean:
@@ -57,7 +57,7 @@ gen:
 	--common-name $(CN) \
 	--client-alt-name $(CLIENT_ALT_NAME) \
 	--server-alt-name $(SERVER_ALT_NAME) \
-	--crl $(CRL) \
+	$(CRL) \
 	--days-of-validity $(DAYS_OF_VALIDITY) \
 	--key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
 
@@ -66,7 +66,7 @@ regen:
 	--common-name $(CN) \
 	--client-alt-name $(CLIENT_ALT_NAME) \
 	--server-alt-name $(SERVER_ALT_NAME) \
-	--crl $(CRL) \
+	$(CRL) \
 	--days-of-validity $(DAYS_OF_VALIDITY) \
 	--key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ PASS = "$(PASSWORD)"
 endif
 
 ifdef CRL
-CRL := "--crl $(CRL)"
+CRL := "--crl $(CRL) \"
 endif
 
 all: regen verify
@@ -66,7 +66,7 @@ regen:
 	--common-name $(CN) \
 	--client-alt-name $(CLIENT_ALT_NAME) \
 	--server-alt-name $(SERVER_ALT_NAME) \
-	$(CRL) \
+	$(CRL)
 	--days-of-validity $(DAYS_OF_VALIDITY) \
 	--key-bits $(NUMBER_OF_PRIVATE_KEY_BITS) $(ECC_FLAGS)
 

--- a/basic/openssl.cnf
+++ b/basic/openssl.cnf
@@ -59,12 +59,14 @@ basicConstraints = critical,CA:true
 basicConstraints = CA:false
 keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
+crlDistributionPoints = URI:@CRL@
 subjectAltName   = @client_alt_names
 
 [ server_extensions ]
 basicConstraints = CA:false
 keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = serverAuth
+crlDistributionPoints = URI:@CRL@
 subjectAltName   = @server_alt_names
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer

--- a/basic/openssl.cnf
+++ b/basic/openssl.cnf
@@ -59,14 +59,14 @@ basicConstraints = critical,CA:true
 basicConstraints = CA:false
 keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
-crlDistributionPoints = URI:@CRL@
+@crlDistributionPoints = URI:CRL@
 subjectAltName   = @client_alt_names
 
 [ server_extensions ]
 basicConstraints = CA:false
 keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = serverAuth
-crlDistributionPoints = URI:@CRL@
+@crlDistributionPoints = URI:CRL@
 subjectAltName   = @server_alt_names
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer

--- a/tls_gen/cli.py
+++ b/tls_gen/cli.py
@@ -13,6 +13,8 @@ def build_parser():
                  help = "Certificate CN (Common Name)", default = socket.gethostname())
     p.add_option("--client-alt-name", dest = "client_alt_name", action = "store",
                  help = "SAN (subject Alternative Name) for the client", default = socket.gethostname())
+    p.add_option("--crl", dest = "crl", action = "store",
+                 help = "CRL for the lists", default = "example.com/fakecrl.crl.pem")
     p.add_option("--server-alt-name", dest = "server_alt_name", action = "store",
                  help = "SAN (subject Alternative Name) for the server", default = socket.gethostname())
     p.add_option("-b", "--key-bits", dest = "key_bits", action = "store",

--- a/tls_gen/cli.py
+++ b/tls_gen/cli.py
@@ -14,7 +14,7 @@ def build_parser():
     p.add_option("--client-alt-name", dest = "client_alt_name", action = "store",
                  help = "SAN (subject Alternative Name) for the client", default = socket.gethostname())
     p.add_option("--crl", dest = "crl", action = "store",
-                 help = "CRL for the lists", default = "example.com/fakecrl.crl.pem")
+                 help = "CRL for the lists")
     p.add_option("--server-alt-name", dest = "server_alt_name", action = "store",
                  help = "SAN (subject Alternative Name) for the server", default = socket.gethostname())
     p.add_option("-b", "--key-bits", dest = "key_bits", action = "store",

--- a/tls_gen/gen.py
+++ b/tls_gen/gen.py
@@ -36,7 +36,10 @@ def get_openssl_cnf_path(opts):
             out_cnf0 = in_cnf.replace('@COMMON_NAME@', cn)
             out_cnf1 = out_cnf0.replace('@CLIENT_ALT_NAME@', client_alt_name)
             out_cnf2 = out_cnf1.replace('@SERVER_ALT_NAME@', server_alt_name)
-            out_cnf3 = out_cnf2.replace('@CRL@', crl)
+            out_cnf3 = out_cnf2
+            if crl:
+                out_cnf3 = out_cnf2.replace('@crlDistributionPoints = URI:CRL@', "crlDistributionPoints = {0}".format(crl))
+
             outfile.write(out_cnf3)
             tmp_cnf_path = outfile.name
 

--- a/tls_gen/gen.py
+++ b/tls_gen/gen.py
@@ -26,6 +26,7 @@ def get_openssl_cnf_path(opts):
     cn = opts.common_name
     client_alt_name = opts.client_alt_name or opts.common_name
     server_alt_name = opts.server_alt_name or opts.common_name
+    crl = opts.crl
     cnf_path = openssl_cnf_path()
     tmp_cnf_path = None
 
@@ -35,7 +36,8 @@ def get_openssl_cnf_path(opts):
             out_cnf0 = in_cnf.replace('@COMMON_NAME@', cn)
             out_cnf1 = out_cnf0.replace('@CLIENT_ALT_NAME@', client_alt_name)
             out_cnf2 = out_cnf1.replace('@SERVER_ALT_NAME@', server_alt_name)
-            outfile.write(out_cnf2)
+            out_cnf3 = out_cnf2.replace('@CRL@', crl)
+            outfile.write(out_cnf3)
             tmp_cnf_path = outfile.name
 
     generated_cnf_file = tmp_cnf_path


### PR DESCRIPTION
This change allows us to specify a CRL endpoint to the CA. This is usefull when servers have online CRL verification enabled and attempt to read the field from the certificate. Of course the CRL needs to be created manually and deployed to an appropriate position and served with an http server.

