### PR TITLE
Fix password generation.

### DIFF
--- a/basic/profile.py
+++ b/basic/profile.py
@@ -6,13 +6,12 @@ import shutil
 
 def _copy_artifacts_to_results():
     os.makedirs(paths.relative_path("result"), exist_ok = True)
-
     gen.copy_root_ca_certificate_and_key_pair()
     gen.copy_leaf_certificate_and_key_pair("server")
     gen.copy_leaf_certificate_and_key_pair("client")
 
 def generate(opts):
-    cli.ensure_password_is_provided(opts)
+    cli.validate_password_if_provided(opts)
     print("Will generate a root CA and two certificate/key pairs (server and client)")
     gen.generate_root_ca(opts)
     gen.generate_server_certificate_and_key_pair(opts)
@@ -41,8 +40,7 @@ def verify(opts):
     verify.verify_leaf_certificate_against_root_ca("server")
 
 def verify_pkcs12(opts):
-    cli.ensure_password_is_provided(opts)
-
+    cli.validate_password_if_provided(opts)
     print("Will verify generated PKCS12 certificate stores...")
     verify.verify_pkcs12_store("client", opts)
     verify.verify_pkcs12_store("server", opts)

--- a/separate_intermediates/profile.py
+++ b/separate_intermediates/profile.py
@@ -28,7 +28,7 @@ def _concat_ca_certificates_of(peer):
     chain_file.close
 
 def generate(opts):
-    cli.ensure_password_is_provided(opts)
+    cli.validate_password_if_provided(opts)
     print("Will generate a root CA")
     gen.generate_root_ca(opts)
     print("Will generate an intermediate CA for server certificate")

--- a/tls_gen/cli.py
+++ b/tls_gen/cli.py
@@ -8,7 +8,7 @@ def build_parser():
     p = OptionParser(usage = "usage: %prog [options] (generate|clean|regenerate|verify|info)")
     p.add_option("-p", "--password",
                  type = "string", dest = "password", action = "store",
-                 help = "Private key password")
+                 help = "Private key password", default = "")
     p.add_option("-n", "--common-name", dest = "common_name", action = "store",
                  help = "Certificate CN (Common Name)", default = socket.gethostname())
     p.add_option("--client-alt-name", dest = "client_alt_name", action = "store",
@@ -48,11 +48,8 @@ def print_known_commands():
     s = ", ".join(list(f.__name__ for f in commands.values()))
     print("Known commands: {}".format(s))
 
-def ensure_password_is_provided(options):
-    if len(options.password) == 0:
-        sys.stderr.write("Private key password must be specified.\n")
-        sys.exit(1)
-    elif len(options.password) < 4 or len(options.password) > 1023:
+def validate_password_if_provided(options):
+    if len(options.password) > 0 and (len(options.password) < 4 or len(options.password) > 1023):
         sys.stderr.write("Password must be between 4 and 1023 characters in length.\n")
         sys.exit(1)
 

--- a/tls_gen/cli.py
+++ b/tls_gen/cli.py
@@ -53,7 +53,7 @@ def ensure_password_is_provided(options):
         sys.stderr.write("Private key password must be specified.\n")
         sys.exit(1)
     elif len(options.password) < 4 or len(options.password) > 1023:
-        sys.stderr.write("Password length out of bounds, you must type in 4 to 1023 characters.\n")
+        sys.stderr.write("Password must be between 4 and 1023 characters in length.\n")
         sys.exit(1)
 
 def run(commands):

--- a/tls_gen/cli.py
+++ b/tls_gen/cli.py
@@ -49,8 +49,11 @@ def print_known_commands():
     print("Known commands: {}".format(s))
 
 def ensure_password_is_provided(options):
-    if options.password is None:
-        sys.stderr.write("Private key password must be specified.")
+    if len(options.password) == 0:
+        sys.stderr.write("Private key password must be specified.\n")
+        sys.exit(1)
+    elif len(options.password) < 4 or len(options.password) > 1023:
+        sys.stderr.write("Password length out of bounds, you must type in 4 to 1023 characters.\n")
         sys.exit(1)
 
 def run(commands):

--- a/tls_gen/gen.py
+++ b/tls_gen/gen.py
@@ -75,6 +75,11 @@ def openssl_ca(opts, *args, **kwargs):
     xs = ["openssl", "ca", "-config", cnf_path] + list(args)
     run(xs, **kwargs)
 
+def openssl_pkcs12(*args, **kwargs):
+    print("=>\t[openssl_pkcs12]")
+    xs = ["openssl", "pkcs12"] + list(args)
+    run(xs, **kwargs)
+
 def prepare_ca_directory(dir_name):
     os.makedirs(relative_path(dir_name), exist_ok = True)
     os.makedirs(relative_path(dir_name, "certs"),   exist_ok = True)
@@ -97,16 +102,19 @@ def prepare_ca_directory(dir_name):
 
 def generate_root_ca(opts):
     prepare_ca_directory(root_ca_path())
-
-    openssl_req(opts,
-                "-x509",
-                "-days",    str(opts.validity_days),
-                "-newkey",  "rsa:{}".format(opts.key_bits),
-                "-keyout",  root_ca_key_path(),
-                "-passout", "pass:{}".format(opts.password),
-                "-out",     root_ca_certificate_path(),
-                "-outform", "PEM",
-                "-subj",    "/CN=TLSGenSelfSignedtRootCA/L=$$$$/")
+    args = ["-x509",
+            "-days",    str(opts.validity_days),
+            "-newkey",  "rsa:{}".format(opts.key_bits),
+            "-keyout",  root_ca_key_path(),
+            "-out",     root_ca_certificate_path(),
+            "-outform", "PEM",
+            "-subj",    "/CN=TLSGenSelfSignedtRootCA/L=$$$$/"]
+    if len(opts.password) > 0:
+        args.append("-passout")
+        args.append("pass:{}".format(opts.password))
+    else:
+        args.append("-nodes")
+    openssl_req(opts, *args)
     openssl_x509("-in",      root_ca_certificate_path(),
                  "-out",     root_ca_certificate_cer_path(),
                  "-outform", "DER")
@@ -127,39 +135,49 @@ def generate_intermediate_ca(opts,
 
     if opts.use_ecc:
         print("Will use Elliptic Curve Cryptography...")
-        openssl_genpkey("-algorithm", "EC",
-                        "-outform",   "PEM",
-                        "-aes256",
-                        "-pass",      "pass:{}".format(opts.password),
-                        "-out",       intermediate_ca_key_path(suffix),
-                        "-pkeyopt",   "ec_paramgen_curve:{}".format(opts.ecc_curve))
+        args = ["-algorithm", "EC",
+                "-outform",   "PEM",
+                "-out",       intermediate_ca_key_path(suffix),
+                "-pkeyopt",   "ec_paramgen_curve:{}".format(opts.ecc_curve)]
     else:
         print("Will use RSA...")
-        openssl_genpkey("-algorithm", "RSA",
-                        "-outform",   "PEM",
-                        "-aes256",
-                        "-pass",      "pass:{}".format(opts.password),
-                        "-out",       intermediate_ca_key_path(suffix),
-                        "-pkeyopt",   "rsa_keygen_bits:{}".format(str(opts.key_bits)))
+        args = ["-algorithm", "RSA",
+                "-outform",   "PEM",
+                "-out",       intermediate_ca_key_path(suffix),
+                "-pkeyopt",   "rsa_keygen_bits:{}".format(str(opts.key_bits))]
 
-    openssl_req(opts,
-                "-new",
-                "-key",     intermediate_ca_key_path(suffix),
-                "-passin",  "pass:{}".format(opts.password),
-                "-out",     intermediate_ca_certificate_csr_path(suffix),
-                "-subj",    "/CN={}/O={}/L=$$$$/".format(opts.common_name, "Intermediate CA {}".format(suffix)),
-                "-passout", "pass:{}".format(opts.password))
-    openssl_ca(opts,
-               "-days",       str(opts.validity_days),
-               "-cert",       parent_certificate_path,
-               "-keyfile",    parent_key_path,
-               "-passin",     "pass:{}".format(opts.password),
-               "-in",         intermediate_ca_certificate_csr_path(suffix),
-               "-out",        intermediate_ca_certificate_path(suffix),
-               "-outdir",     intermediate_ca_certs_path(suffix),
-               "-notext",
-               "-batch",
-               "-extensions", "ca_extensions")
+    if len(opts.password) > 0:
+        args.append("-aes256")
+        args.append("-pass")
+        args.append("pass:{}".format(opts.password))
+    openssl_genpkey(*args)
+
+    args = ["-new",
+            "-key",     intermediate_ca_key_path(suffix),
+            "-out",     intermediate_ca_certificate_csr_path(suffix),
+            "-subj",    "/CN={}/O={}/L=$$$$/".format(opts.common_name, "Intermediate CA {}".format(suffix))]
+    if len(opts.password) > 0:
+        args.append("-passin")
+        args.append("pass:{}".format(opts.password))
+        args.append("-passout")
+        args.append("pass:{}".format(opts.password))
+    else:
+        args.append("-nodes")
+    openssl_req(opts, *args)
+
+    args = ["-days",       str(opts.validity_days),
+            "-cert",       parent_certificate_path,
+            "-keyfile",    parent_key_path,
+            "-in",         intermediate_ca_certificate_csr_path(suffix),
+            "-out",        intermediate_ca_certificate_path(suffix),
+            "-outdir",     intermediate_ca_certs_path(suffix),
+            "-notext",
+            "-batch",
+            "-extensions", "ca_extensions"]
+    if len(opts.password) > 0:
+        args.append("-passin")
+        args.append("pass:{}".format(opts.password))
+    openssl_ca(opts, *args)
 
 
 #
@@ -185,45 +203,58 @@ def generate_leaf_certificate_and_key_pair(peer, opts,
 
     if opts.use_ecc:
         print("Will use Elliptic Curve Cryptography...")
-        openssl_genpkey("-algorithm", "EC",
-                        "-outform",   "PEM",
-                        "-aes256",
-                        "-pass",      "pass:{}".format(opts.password),
-                        "-out",       leaf_key_path(peer),
-                        "-pkeyopt",   "ec_paramgen_curve:{}".format(opts.ecc_curve))
+        args = ["-algorithm", "EC",
+                "-outform",   "PEM",
+                "-out",       leaf_key_path(peer),
+                "-pkeyopt",   "ec_paramgen_curve:{}".format(opts.ecc_curve)]
     else:
         print("Will use RSA...")
-        openssl_genpkey("-algorithm", "RSA",
-                        "-outform",   "PEM",
-                        "-aes256",
-                        "-pass",      "pass:{}".format(opts.password),
-                        "-out",       leaf_key_path(peer),
-                        "-pkeyopt",   "rsa_keygen_bits:{}".format(str(opts.key_bits)))
+        args = ["-algorithm", "RSA",
+                "-outform",   "PEM",
+                "-out",       leaf_key_path(peer),
+                "-pkeyopt",   "rsa_keygen_bits:{}".format(str(opts.key_bits))]
 
-    openssl_req(opts,
-                "-new",
-                "-key",     leaf_key_path(peer),
-                "-passin",  "pass:{}".format(opts.password),
-                "-keyout",  leaf_certificate_path(peer),
-                "-passout", "pass:{}".format(opts.password),
-                "-out",     relative_path(peer, "req.pem"),
-                "-outform", "PEM",
-                "-subj",    "/CN={}/O={}/L=$$$$/".format(opts.common_name, peer))
-    openssl_ca(opts,
-               "-days",    str(opts.validity_days),
-               "-cert",    parent_certificate_path,
-               "-keyfile", parent_key_path,
-               "-passin", "pass:{}".format(opts.password),
-               "-in",      relative_path(peer, "req.pem"),
-               "-out",     leaf_certificate_path(peer),
-               "-outdir",  parent_certs_path,
-               "-notext",
-               "-batch",
-               "-extensions", "{}_extensions".format(peer))
-    run(["openssl", "pkcs12",
-          "-export",
-          "-out",     relative_path(peer, "keycert.p12"),
-          "-in",      leaf_certificate_path(peer),
-          "-inkey",   leaf_key_path(peer),
-          "-passin",  "pass:{}".format(opts.password),
-          "-passout", "pass:{}".format(opts.password)])
+    if len(opts.password) > 0:
+        args.append("-aes256")
+        args.append("-pass")
+        args.append("pass:{}".format(opts.password))
+    openssl_genpkey(*args)
+
+    args = ["-new",
+            "-key",     leaf_key_path(peer),
+            "-keyout",  leaf_certificate_path(peer),
+            "-out",     relative_path(peer, "req.pem"),
+            "-outform", "PEM",
+            "-subj",    "/CN={}/O={}/L=$$$$/".format(opts.common_name, peer)]
+    if len(opts.password) > 0:
+        args.append("-passin")
+        args.append("pass:{}".format(opts.password))
+        args.append("-passout")
+        args.append("pass:{}".format(opts.password))
+    else:
+        args.append("-nodes")
+    openssl_req(opts, *args)
+
+    args = ["-days",    str(opts.validity_days),
+            "-cert",    parent_certificate_path,
+            "-keyfile", parent_key_path,
+            "-in",      relative_path(peer, "req.pem"),
+            "-out",     leaf_certificate_path(peer),
+            "-outdir",  parent_certs_path,
+            "-notext",
+            "-batch",
+            "-extensions", "{}_extensions".format(peer)]
+    if len(opts.password) > 0:
+        args.append("-passin")
+        args.append("pass:{}".format(opts.password))
+    openssl_ca(opts, *args)
+
+    args = ["-export",
+            "-out",     relative_path(peer, "keycert.p12"),
+            "-in",      leaf_certificate_path(peer),
+            "-inkey",   leaf_key_path(peer),
+            "-passout", "pass:{}".format(opts.password)]
+    if len(opts.password) > 0:
+        args.append("-passin")
+        args.append("pass:{}".format(opts.password))
+    openssl_pkcs12(*args)

--- a/two_shared_intermediates/profile.py
+++ b/two_shared_intermediates/profile.py
@@ -24,7 +24,7 @@ def _concat_certificates():
     chain_file.close
 
 def generate(opts):
-    cli.ensure_password_is_provided(opts)
+    cli.validate_password_if_provided(opts)
     print("Will generate a root CA and two certificate/key pairs (server and client)")
     gen.generate_root_ca(opts)
     print("Will generate first intermediate CA signed by the root CA")


### PR DESCRIPTION
Fixes #21 

Fix `cli.py`:

- When the `PASSWORD` variable is not provided, `options.password` is an empty string instead of None type.

- openssl has boundaries for password length, so I added a check for this as well. Example error message from openssl: UI routines:UI_set_result_ex:result too small:crypto/ui/ui_lib.c:905:You must type in 4 to 1023 characters

  - It seems that the 1023 boundary happens when *decrypting* a key. If I try to *encrypt* a key, the message actually states 1024 chars as the upper limit. I went with the lowest number for the check since the script needs to encrypt and decrypt with the same password.

Fix `gen.py`:

- I couldn't find a way to encrypt the key when using `ecparam`. Also,  [genrsa](https://www.openssl.org/docs/manmaster/man1/openssl-genrsa.html#DESCRIPTION) is deprecated. Therefore, I replaced both with [genpkey](https://www.openssl.org/docs/manmaster/man1/openssl-genpkey.html).

- The main problem that was preventing the correct usage of the password option was `-nodes`, which makes openssl *not* encrypt the private key. [Source](https://www.openssl.org/docs/manmaster/man1/openssl-req.html#nodes)

- I picked the `aes256` cipher to encrypt the key for no particular reason. Since this application is "meant to be used in development and QA environments", I don't think that the cipher choice should matter too much.

- I removed the `-days` option from the last call to openssl_req since it is [ignored](https://www.openssl.org/docs/manmaster/man1/openssl-req.html) when `-x509` is not used. Just to silence an informational message that may confuse users:

    ```shell
    =>	[openssl_req]
    Ignoring -days; not generating a certificate
    =>	[openssl_ca]
    ```

To test the changes, I ran every command from the readme, followed by checks like:
```shell
# PASSWORD=bunnies
## Must print all keys
find . -iname "*key.pem" -exec openssl pkey -passin pass:bunnies -in '{}' \;
find . -iname "*key.p12" -exec openssl pkcs12 -nokeys -passin pass:bunnies -in '{}' \;

## Must throw an error for all keys
find . -iname "*key.pem" -exec openssl pkey -passin pass:bunnie5 -in '{}' \;
find . -iname "*key.p12" -exec openssl pkcs12 -nokeys -passin pass:bunnie5 -in '{}' \;
```