### PR TITLE
Fixed the way of referencing another makefile

### DIFF
--- a/basic/Makefile
+++ b/basic/Makefile
@@ -1,1 +1,1 @@
-../Makefile
+include ../Makefile


### PR DESCRIPTION
Hi, the way you referenced the main Makefile in the folder basic was causing the following error message for me:
Makefile:1: *** missing separator.  Stop.

Following the [GNU make documentation](https://www.gnu.org/software/make/manual/html_node/Include.html) it indicates to use the word include instead.