### PR TITLE
Add ALT names properties to non-basic profiles

### DIFF
--- a/separate_intermediates/openssl.cnf
+++ b/separate_intermediates/openssl.cnf
@@ -1,3 +1,12 @@
+# Copied over from the Basic profile
+# Note: LibreSSL 2.2.7 does not correctly support environment variables
+# here and that is the version that ships with OS X High Sierra. So, we
+# replace text using Python and generate a temporary cnf file
+
+common_name = @COMMON_NAME@
+client_alt_name = @CLIENT_ALT_NAME@
+server_alt_name = @SERVER_ALT_NAME@
+
 [ ca ]
 default_ca = test_root_ca
 
@@ -54,10 +63,27 @@ keyUsage         = keyCertSign, cRLSign
 basicConstraints = CA:false
 keyUsage         = digitalSignature
 extendedKeyUsage = clientAuth
+subjectAltName   = @client_alt_names
 
 [ server_extensions ]
 basicConstraints = CA:false
 keyUsage         = keyEncipherment
 extendedKeyUsage = serverAuth
+subjectAltName   = @server_alt_names
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer
+
+[ client_alt_names ]
+DNS.1 = $common_name
+DNS.2 = $client_alt_name
+DNS.3 = localhost
+# examples of more Subject Alternative Names
+# DNS.4 = guest
+# email = guest@warp10.local
+# URI   = amqps://123.client.warp10.local
+# otherName = 1.3.6.1.4.1.54392.5.436;FORMAT:UTF8,UTF8String:other-username
+
+[ server_alt_names ]
+DNS.1 = $common_name
+DNS.2 = $server_alt_name
+DNS.3 = localhost

--- a/two_shared_intermediates/openssl.cnf
+++ b/two_shared_intermediates/openssl.cnf
@@ -1,3 +1,12 @@
+# Copied over from the Basic profile
+# Note: LibreSSL 2.2.7 does not correctly support environment variables
+# here and that is the version that ships with OS X High Sierra. So, we
+# replace text using Python and generate a temporary cnf file
+
+common_name = @COMMON_NAME@
+client_alt_name = @CLIENT_ALT_NAME@
+server_alt_name = @SERVER_ALT_NAME@
+
 [ ca ]
 default_ca = test_root_ca
 
@@ -54,10 +63,27 @@ keyUsage         = keyCertSign, cRLSign
 basicConstraints = CA:false
 keyUsage         = digitalSignature
 extendedKeyUsage = clientAuth
+subjectAltName   = @client_alt_names
 
 [ server_extensions ]
 basicConstraints = CA:false
 keyUsage         = keyEncipherment
 extendedKeyUsage = serverAuth
+subjectAltName   = @server_alt_names
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer
+
+[ client_alt_names ]
+DNS.1 = $common_name
+DNS.2 = $client_alt_name
+DNS.3 = localhost
+# examples of more Subject Alternative Names
+# DNS.4 = guest
+# email = guest@warp10.local
+# URI   = amqps://123.client.warp10.local
+# otherName = 1.3.6.1.4.1.54392.5.436;FORMAT:UTF8,UTF8String:other-username
+
+[ server_alt_names ]
+DNS.1 = $common_name
+DNS.2 = $server_alt_name
+DNS.3 = localhost


### PR DESCRIPTION
The openssl configuration template was missing the extensions to add SAN properties to the certificates, resulting in certificates not having the expected Subject Alt Names, despite setting `CLIENT_ALT_NAME` and `SERVER_ALT_NAME`.
