### PR TITLE
Update keyUsage to allow ECC and RSA cipher suites

### DIFF
--- a/separate_intermediates/openssl.cnf
+++ b/separate_intermediates/openssl.cnf
@@ -61,13 +61,13 @@ keyUsage         = keyCertSign, cRLSign
 
 [ client_extensions ]
 basicConstraints = CA:false
-keyUsage         = digitalSignature
+keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
 subjectAltName   = @client_alt_names
 
 [ server_extensions ]
 basicConstraints = CA:false
-keyUsage         = keyEncipherment
+keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName   = @server_alt_names
 subjectKeyIdentifier = hash

--- a/two_shared_intermediates/openssl.cnf
+++ b/two_shared_intermediates/openssl.cnf
@@ -61,13 +61,13 @@ keyUsage         = keyCertSign, cRLSign
 
 [ client_extensions ]
 basicConstraints = CA:false
-keyUsage         = digitalSignature
+keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth
 subjectAltName   = @client_alt_names
 
 [ server_extensions ]
 basicConstraints = CA:false
-keyUsage         = keyEncipherment
+keyUsage         = digitalSignature,keyEncipherment
 extendedKeyUsage = serverAuth
 subjectAltName   = @server_alt_names
 subjectKeyIdentifier = hash


### PR DESCRIPTION
By having digitalSignature on the client and keyEncipherment on the
server, we may run into this problem:

https://groups.google.com/g/rabbitmq-users/c/3TQFT8jX-bk?pli=1

Some versions of OpenSSL do not seem affected, or perhaps they had a
bug back in 2018. In openssl `1.0.2za-fips 24 Aug 2021`, we receive the
"insufficient security" error if the client and server certificates do
not have both key usages. According to this doc:

https://rabbitmq.com/ssl.html#key-usage-effects-on-cipher-suites

The filtering based on key usage will result in client and server not
having any common cipher suites to agree on.